### PR TITLE
#94; sources run.env.

### DIFF
--- a/steps/bash/setup/environmentVariables/footer.sh
+++ b/steps/bash/setup/environmentVariables/footer.sh
@@ -1,3 +1,5 @@
+export_run_variables
+
 stop_group
 if $H_FLAG_UNSET; then
   set -H


### PR DESCRIPTION
#94 

The environment variables are available in `onStart` and `onExecute`, and should be available in `onSuccess` and `onFailure` as well.