### PR TITLE
#151; adds bitbucketServerBasicAuth to update_commit_status.

### DIFF
--- a/steps/bash/header.sh
+++ b/steps/bash/header.sh
@@ -519,6 +519,23 @@ update_commit_status() {
       endpoint="$integration_url/2.0/repositories/$full_name/commit/$commit/statuses/build"
       headers="-H Authorization:'Basic $token'"
       ;;
+    bitbucketServerBasic )
+      local username=$(eval echo "$"res_"$resourceName"_int_username)
+      local password=$(eval echo "$"res_"$resourceName"_int_password)
+      local token=$( echo -n "$username:$password" | base64 )
+      local state=""
+      if [ "$opt_status" == "processing" ] ; then
+        state="INPROGRESS"
+      elif [ "$opt_status" == "success" ] ; then
+        state="SUCCESSFUL"
+      elif [ "$opt_status" == "failure" ] ; then
+        state="FAILED"
+      fi
+
+      payload="{\"url\": \"\${STEP_URL}\",\"description\": \"\${opt_message}\", \"key\": \"\${opt_context}\", \"name\": \"\${STEP_NAME}\", \"state\": \"$state\"}"
+      endpoint="$integration_url/rest/build-status/1.0/commits/$commit"
+      headers="-H Authorization:'Basic $token'"
+      ;;
     *)
       echo "Error: unsupported provider: $i_mastername" >&2
       exit 99


### PR DESCRIPTION
#151 

Only adds `bitbucketServerBasicAuth` because the other Bitbucket Server integration appears to have been removed.

Confirmed that statuses can be updated for commit, pull request, and tag webhooks.