### PR TITLE
#153; adds default commit statuses to update_commit_status.

### DIFF
--- a/steps/bash/execution/onComplete/header.sh
+++ b/steps/bash/execution/onComplete/header.sh
@@ -1,1 +1,2 @@
 onComplete() {
+export CURRENT_SCRIPT_SECTION="onComplete"

--- a/steps/bash/execution/onExecute/header.sh
+++ b/steps/bash/execution/onExecute/header.sh
@@ -1,1 +1,2 @@
 start_group "Executing step" true
+export CURRENT_SCRIPT_SECTION="onExecute"

--- a/steps/bash/execution/onFailure/header.sh
+++ b/steps/bash/execution/onFailure/header.sh
@@ -1,1 +1,2 @@
 onFailure() {
+export CURRENT_SCRIPT_SECTION="onFailure"

--- a/steps/bash/execution/onStart/header.sh
+++ b/steps/bash/execution/onStart/header.sh
@@ -1,1 +1,2 @@
 start_group "onStart" "true"
+export CURRENT_SCRIPT_SECTION="onStart"

--- a/steps/bash/execution/onSuccess/header.sh
+++ b/steps/bash/execution/onSuccess/header.sh
@@ -1,1 +1,2 @@
 onSuccess() {
+export CURRENT_SCRIPT_SECTION="onSuccess"

--- a/steps/bash/header.sh
+++ b/steps/bash/header.sh
@@ -415,7 +415,7 @@ compare_git() {
 
 update_commit_status() {
   if [[ $# -le 0 ]]; then
-    echo "Usage: update_commit_status RESOURCE --status STATUS [--message \"MESSAGE\" --context CONTEXT]" >&2
+    echo "Usage: update_commit_status RESOURCE [--status STATUS --message \"MESSAGE\" --context CONTEXT]" >&2
     exit 99
   fi
 
@@ -465,8 +465,28 @@ update_commit_status() {
   done
 
   if [ -z "$opt_status" ]; then
-    echo "Error: --status is required" >&2
-    exit 99
+    case "$CURRENT_SCRIPT_SECTION" in
+      onStart | onExecute )
+        opt_status="processing"
+        ;;
+      onSuccess )
+        opt_status="success"
+        ;;
+      onFailure )
+        opt_status="failure"
+        ;;
+      onComplete )
+        if [ "$is_success" == "true" ]; then
+          opt_status="success"
+        else
+          opt_status="failure"
+        fi
+        ;;
+      *)
+        echo "Error: unable to determine status in section $CURRENT_SCRIPT_SECTION" >&2
+        exit 99
+        ;;
+    esac
   fi
 
   if [ "$opt_status" != "processing" ] && [ "$opt_status" != "success" ] && [ "$opt_status" != "failure" ] ; then


### PR DESCRIPTION
#153 

Checked statuses sent from each section.  When `onSuccess` fails, it does not continue to `onComplete`.