### PR TITLE
don't print the command on retry

### DIFF
--- a/steps/bash/header.sh
+++ b/steps/bash/header.sh
@@ -1326,7 +1326,6 @@ retry_command() {
       [ $ret -eq 0 ] && break;
     } || {
       echo "retrying $i of 3 times..."
-      echo "$@"
     }
   done
   return $ret


### PR DESCRIPTION
closes https://github.com/Shippable/kermit-execTemplates/issues/179