### PR TITLE
adds check for commands before executing

### DIFF
--- a/steps/powershell/footer.ps1
+++ b/steps/powershell/footer.ps1
@@ -10,18 +10,28 @@ Function main() {
   $global:is_success = $TRUE
   Try
   {
-    onStart
-    onExecute
-    execute_command "onSuccess"
+    if (Get-Command "onStart" -errorAction SilentlyContinue) {
+      onStart
+    }
+    if (Get-Command "onExecute" -errorAction SilentlyContinue) {
+      onExecute
+    }
+    if (Get-Command "onSuccess" -errorAction SilentlyContinue) {
+      execute_command "onSuccess"
+    }
   }
   Catch
   {
     $global:is_success = $FALSE
-    execute_command "onFailure"
+    if (Get-Command "onFailure" -errorAction SilentlyContinue) {
+      execute_command "onFailure"
+    }
   }
   Finally
   {
-    execute_command "onComplete"
+    if (Get-Command "onComplete" -errorAction SilentlyContinue) {
+      execute_command "onComplete"
+    }
     before_exit
   }
 }


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/200

When we leave out onStart, onExecute, onSuccess, onFailure, onComplete sections in the YML, the respective functions(commands) are not generated for execution. So, we need to check each command before executing them.

```yml
      - name: test_basic_execute
        type: powershell
        requires:
          steps:
            - start
        execution:
          onExecute:
            - Write-Output "hi"

      - name: test_basic_full_execute
        type: powershell
        requires:
          steps:
            - start
        execution:
          onStart:
            - Write-Output "starting onStart"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onExecute:
            - Write-Output "starting onExecute"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onSuccess:
            - Write-Output "starting onSuccess"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
          onComplete:
            - Write-Output "starting onComplete"
            - Write-Output "CURRENT_SCRIPT_SECTION = $env:CURRENT_SCRIPT_SECTION"
```

#### Before
`test_basic_execute` fails and `test_basic_full_execute` passes.

#### After
Both the steps pass.