### PR TITLE
#235; pulls the runtime image.

### DIFF
--- a/steps/bash/setup/runtime/image/image.sh
+++ b/steps/bash/setup/runtime/image/image.sh
@@ -11,6 +11,14 @@ boot_container() {
     exit $exit_code
   }
 
+  local image_autopull="%%context.autoPull%%"
+
+  if [ "$image_autopull" == "true" ]; then
+    start_group "Pulling Image"
+    execute_command "docker pull $DOCKER_IMAGE"
+    stop_group
+  fi
+
   start_group "Booting Container"
   local default_docker_options="-v /opt/docker/docker:/usr/bin/docker \
     -v /var/run/docker.sock:/var/run/docker.sock \


### PR DESCRIPTION
#235 

Pulls the runtime image before `docker run` to be sure it is the latest.

Already present:
<img width="1134" alt="Screen Shot 2019-05-28 at 10 06 19 AM" src="https://user-images.githubusercontent.com/5492015/58503579-c7684b80-813d-11e9-9128-36bd2361e7b4.png">

Pulling custom image:
<img width="1138" alt="Screen Shot 2019-05-28 at 10 09 19 AM" src="https://user-images.githubusercontent.com/5492015/58503581-c7684b80-813d-11e9-81cb-1e78239753f0.png">

Default `auto` image:
<img width="1132" alt="Screen Shot 2019-05-28 at 11 15 36 AM" src="https://user-images.githubusercontent.com/5492015/58503582-c7684b80-813d-11e9-9574-1c72fb8f1f5b.png">
