### PR TITLE
#267; adds a new error message for update_commit_status.

### DIFF
--- a/steps/bash/header.sh
+++ b/steps/bash/header.sh
@@ -423,6 +423,12 @@ update_commit_status() {
   local resourceName="$1"
   shift
 
+  local resource_id=$(eval echo "$"res_"$resourceName"_resourceId)
+  if [ -z "$resource_id" ]; then
+    echo "Error: resource not found for $resourceName" >&2
+    exit 99
+  fi
+
   local integration_name=$(eval echo "$"res_"$resourceName"_int_name)
   if [ -z "$integration_name" ]; then
     echo "Error: integration data not found for $resourceName" >&2


### PR DESCRIPTION
#267 

Since every resource should have a `resourceId`, this uses that to determine if the resource actually exists.