### PR TITLE
update onExecute script for aql

### DIFF
--- a/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
+++ b/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
@@ -111,12 +111,10 @@ constructQueryForAqlResource() {
 
   mappings=$(jq -r ".resources."$aqlResName".resourceVersionContentPropertyBag.mappings" $step_json_path)
   if [ ! -z "$mappings" ] && [ "$mappings" != "null" ]; then
-    local mappingKeys=$(echo $mappings | jq 'keys')
-    local mappingKeyCount=$(echo $mappingKeys | jq '. | length')
-    if [ $mappingKeyCount -ne 0 ]; then
-      for i in $(seq 1 $mappingKeyCount); do
-        local mappingKey=$(echo $mappingKeys | jq '.['"$i-1"']')
-        local mappingValue=$(echo $mappings | jq -r ".$mappingKey")
+    local mappingCount=$(echo $mappings | jq '. | length')
+    if [ $mappingCount -ne 0 ]; then
+      for i in $(seq 1 $mappingCount); do
+        local mappingValue=$(echo $mappings | jq '.['"$i-1"'] | del(.name)')
         aqlQuery=$(echo $aqlQuery | jq --argjson json "$mappingValue" '.mappings += [ $json ]')
       done
     fi


### PR DESCRIPTION
closes #314

produces same output as the old code given the same input (in the new format)

old
```json
{
  "aql": "whatisthis",
  "query_name": "stuff",
  "mappings": [
    {
      "input": "hello",
      "output": "world"
    },
    {
      "input": "foo",
      "output": "bar"
    }
  ],
  "added_props": []
}

```
new
```json
{
  "aql": "whatisthis",
  "query_name": "stuff",
  "mappings": [
    {
      "input": "hello",
      "output": "world"
    },
    {
      "input": "foo",
      "output": "bar"
    }
  ],
  "added_props": []
}
```