### PR TITLE
#339; updates SignReleaseBundle validation.

### DIFF
--- a/steps/SignReleaseBundle/validate.json
+++ b/steps/SignReleaseBundle/validate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "http://json-schema.org/draft-07/schema#",
-  "$id": "http://jfrog.com/cicd/steps/step.schema.json",
+  "$id": "http://jfrog.com/pipelines/steps/SignReleaseBundle.schema.json",
   "type": "object",
   "properties": {
     "name": {
@@ -31,52 +31,68 @@
         },
         "chronological": {
           "type": "boolean"
-        }
-      }
-    },
-    "requires": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "resources": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
-        "steps": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
         },
         "integrations": {
           "type": "array",
+          "minItems": 1,
           "items": {
-            "type": "string"
-          },
-          "minItems": 1
-        }
-      },
-      "required": ["integrations"]
-    },
-    "triggeredBy": {
-      "type": "object",
-      "additionalProperties": false,
-      "properties": {
-        "resources": {
-          "type": "array",
-          "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
           }
         },
-        "steps": {
+        "inputSteps": {
           "type": "array",
+          "minItems": 1,
           "items": {
-            "type": "string"
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "inputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "boolean"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "outputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
           }
         }
-      }
+      },
+      "required": ["integrations", "inputResources"]
     },
     "execution": {
       "type": "object",
@@ -113,18 +129,12 @@
           }
         }
       }
-    },
-    "outputResources": {
-      "type": "array",
-      "items": {
-        "type": "string"
-      }
     }
   },
   "required": [
     "name",
     "type",
-    "requires"
+    "configuration"
   ],
   "additionalProperties": false
 }


### PR DESCRIPTION
#339 

Both `integrations` and `inputResources` are required.  The `dryRun` option will not be added after all.  