### PR TITLE
use existing values

### DIFF
--- a/steps/Bash/header.sh
+++ b/steps/Bash/header.sh
@@ -873,8 +873,6 @@ send_notification() {
   export opt_text="$NOTIFY_TEXT"
   if [ -z "$opt_text" ]; then
     # set up default text
-    local step_name=$(cat "$step_json_path" | jq -r ."step.name")
-    local step_id=$(cat "$step_json_path" | jq -r ."step.id")
     case "$current_script_section" in
       onStart | onExecute )
         opt_text="${step_name} PROCESSING <${step_url}|#${step_id}>"


### PR DESCRIPTION
closes #360

since step_name and step_id are official read-only variables, we can just remove the lines that attempt to define them again.