### PR TITLE
Adds validate.json for GradleBuild

### DIFF
--- a/steps/GradleBuild/validate.json
+++ b/steps/GradleBuild/validate.json
@@ -1,0 +1,226 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://jfrog.com/pipelines/steps/GradleBuild.schema.json",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["GradleBuild"]
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "affinityGroup": {
+          "type": "string"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "nodePool": {
+          "type": "string"
+        },
+        "chronological": {
+          "type": "boolean"
+        },
+        "environmentVariables": {
+          "type": "object",
+          "additionalProperties": {
+            "type": ["string", "number"]
+          }
+        },
+        "runtime": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["image", "host"]
+            }
+          },
+          "required": ["type"],
+          "if": {
+            "properties": {
+              "type": { "enum": ["image"] }
+            }
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["image"] },
+              "image": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "auto": {
+                    "type": "object",
+                    "required": ["language"],
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "versions": {
+                        "type": "array",
+                        "items":  {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "custom": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "tag"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "string"
+                      },
+                      "autoPull": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "else": {
+            "properties": {
+              "type": { "enum": ["host"] }
+            },
+            "additionalProperties": false
+          }
+        },
+        "integrations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "inputSteps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "inputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "boolean"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "outputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "sourceLocation": {
+          "type": "string"
+        },
+        "gradleCommand": {
+          "type": "string"
+        },
+        "configFileLocation": {
+          "type": "string"
+        },
+        "configFileName": {
+          "type": "string"
+        }
+      },
+      "required": ["inputResources", "integrations", "gradleCommand",
+        "configFileLocation", "configFileName", "sourceLocation"]
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "onStart": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onSuccess": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onFailure": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onComplete": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onCancel": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "type",
+    "configuration"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/369

#### Valid YML
```yml
resources:
  - name: gitrepo_1
    type: GitRepo
    configuration:
      gitProvider: github
      path: scriptnull/jp
      sha: jfrog-samples

pipelines:
  - name: test_pipeline
    steps:
      - name: start
        type: GradleBuild
        configuration:
          gradleCommand: clean build -b build.gradle
          sourceLocation: ./gradle-examples/gradle-example-minimal
          configFileLocation: .
          configFileName: gradle-art-config
          inputResources:
            - name: gitrepo_1
          integrations:
            - name: art
        execution:
          # install gradle onStart
          onStart:
            - apt install default-jdk
            - wget https://gradle.org/next-steps/?version=5.4.1&format=bin
            - mkdir /opt/gradle
            - unzip -d /opt/gradle gradle-5.4.1-bin.zip
            - ls /opt/gradle/gradle-5.4.1
            - export PATH=$PATH:/opt/gradle/gradle-5.4.1/bin
```

#### Invalid YML
```yml
#### should fail as there is missing configuration objects            
      - name: missing_required
        type: GradleBuild
        configuration:
          inputResources:
            - name: gitrepo_1
          integrations:
            - name: art
        execution:
          # install gradle onStart
          onStart:
            - apt install default-jdk
            - wget https://gradle.org/next-steps/?version=5.4.1&format=bin
            - mkdir /opt/gradle
            - unzip -d /opt/gradle gradle-5.4.1-bin.zip
            - ls /opt/gradle/gradle-5.4.1
            - export PATH=$PATH:/opt/gradle/gradle-5.4.1/bin
```

#### Before adding validate.json
![image](https://user-images.githubusercontent.com/4211715/59186800-73c01e00-8b91-11e9-94e0-9b1cdfb9541c.png)

#### After adding validate.json
![image](https://user-images.githubusercontent.com/4211715/59186858-97836400-8b91-11e9-9a23-4f4692147b85.png)

