### PR TITLE
removes onExecute from MvnBuild

### DIFF
--- a/steps/MvnBuild/validate.json
+++ b/steps/MvnBuild/validate.json
@@ -190,12 +190,6 @@
             "type": "string"
           }
         },
-        "onExecute": {
-          "type": "array",
-          "items": {
-            "type": "string"
-          }
-        },
         "onSuccess": {
           "type": "array",
           "items": {


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/369

Found out that MvnBuild is allowing `onExecute` section while referring its validate.json script for developing GradleBuild. So fixing it.

```yml
      - name: build_mvn
        type: MvnBuild
        configuration:
          sourceLocation: ./artifactory-maven-plugin-example
          mvnCommand: clean install -f ./pom.xml
          configFileLocation: .
          configFileName: mvn-art-config
          inputSteps:
            - name: start
          inputResources:
            - name: gitrepo_1
          integrations:
            - name: art
        execution:
          onStart:
            - apt install default-jdk
            - pushd /tmp
            - wget http://mirrors.estointernet.in/apache/maven/maven-3/3.6.1/binaries/apache-maven-3.6.1-bin.tar.gz
            - tar xzvf apache-maven-3.6.1-bin.tar.gz
            - export PATH=$PATH:/tmp/apache-maven-3.6.1/bin
            - export M2_HOME=/tmp/apache-maven-3.6.1/
            - popd
            - javac -version
            - mvn --version
          onExecute:
            - echo "this should error in pipeline sync"
```

#### Before 
![image](https://user-images.githubusercontent.com/4211715/59187585-64da6b00-8b93-11e9-97ab-f925699913c5.png)


#### After
![image](https://user-images.githubusercontent.com/4211715/59187638-7b80c200-8b93-11e9-9070-27a0cbfb3996.png)
