### PR TITLE
#374; fixes replicate.json path.

### DIFF
--- a/steps/Bash/header.sh
+++ b/steps/Bash/header.sh
@@ -711,7 +711,7 @@ replicate_resource() {
   fi
 
   # copy values
-  local resource_directory=$(cat "$step_json_path" | jq -r ."resources.$resFrom.resourcePath")
+  local resource_directory=$(cat "$step_json_path" | jq -r ."resources.$resTo.resourcePath")
   local mdFilePathTo="$resource_directory/replicate.json"
 
   if [ ! -f "$mdFilePathTo" ]; then


### PR DESCRIPTION
#374 

Fixes the path for the `replicate.json`.