### PR TITLE
adds onExecute for GradleBuild

### DIFF
--- a/steps/GradleBuild/execution/onExecute/onExecute.sh
+++ b/steps/GradleBuild/execution/onExecute/onExecute.sh
@@ -1,0 +1,44 @@
+GradleBuild() {
+  echo "[GradleBuild] Authenticating with integration: $artifactoryIntegrationName"
+  local rtUrl=$(eval echo "$"int_"$artifactoryIntegrationName"_url)
+  local rtUser=$(eval echo "$"int_"$artifactoryIntegrationName"_user)
+  local rtApiKey=$(eval echo "$"int_"$artifactoryIntegrationName"_apikey)
+  retry_command jfrog rt config --url "$rtUrl" --user "$rtUser" --apikey "$rtApiKey" --interactive=false
+
+  buildName="$pipeline_name"
+  buildNumber="$run_number"
+
+  sourceLocation=$(jq -r ".step.configuration.sourceLocation" $step_json_path)
+  configFileLocation=$(jq -r ".step.configuration.configFileLocation" $step_json_path)
+  configFileName=$(jq -r ".step.configuration.configFileName" $step_json_path)
+
+  buildDir=$(eval echo "$"res_"$inputGitRepoResourceName"_resourcePath)/$sourceLocation
+
+  echo "[GradleBuild] Changing directory: $buildDir"
+  pushd "$buildDir"
+    if [ ! -z "$inputFileResourceName" ]; then
+      filePath=$(eval echo "$"res_"$inputFileResourceName"_resourcePath)/*
+      echo "[GradleBuild] Copying files from: $filePath to: $(pwd)"
+      # todo: remove -v
+      cp -vr $filePath .
+    fi
+
+    gradleCommand=$(jq -r ".step.configuration.gradleCommand" $step_json_path)
+    gradleCommand=$(eval echo "$gradleCommand")
+
+    echo "[GradleBuild] Building module with gradleCommand: $gradleCommand"
+    jfrog rt gradle "$gradleCommand" "$configFileLocation"/"$configFileName" --build-name "$buildName" --build-number "$buildNumber"
+
+    echo "[GradleBuild] Adding build information to run state"
+    add_run_variable buildStepName="$step_name"
+    add_run_variable "$step_name"_payloadType=gradle
+    add_run_variable "$step_name"_buildNumber="$buildNumber"
+    add_run_variable "$step_name"_buildName="$buildName"
+    add_run_variable "$step_name"_isPromoted=false
+  popd
+
+  jfrog rt bce "$buildName" "$buildNumber"
+  save_run_state /tmp/jfrog/. jfrog
+}
+
+execute_command GradleBuild


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/376

#### YML 

```yml
resources:
  - name: git_project
    type: GitRepo
    configuration:
      gitProvider: github
      path: scriptnull/project-examples
      sha: master

pipelines:
  - name: test_pipeline
    steps:
      - name: start
        type: GradleBuild
        configuration:
          gradleCommand: clean artifactoryPublish -b build.gradle
          sourceLocation: gradle-examples/gradle-example-minimal
          configFileLocation: .
          configFileName: gradle-art-config
          inputResources:
            - name: git_project
          integrations:
            - name: art
          runtime:
            type: host
        execution:
          # install gradle before running this build
          onStart:
            - ls -la /opt
            - uname -a
            - export PATH=$PATH:/opt/gradle/gradle-5.4.1/bin
```

#### GradleBuild output
![image](https://user-images.githubusercontent.com/4211715/59246199-4038ce80-8c39-11e9-89b0-fb1f3c07c035.png)

#### .jar file in Artifactory
![image](https://user-images.githubusercontent.com/4211715/59246277-76764e00-8c39-11e9-9253-c239f7e2f884.png)


