### PR TITLE
#389; updates SignReleaseBundle.

### DIFF
--- a/steps/SignReleaseBundle/execution/onExecute/onExecute.sh
+++ b/steps/SignReleaseBundle/execution/onExecute/onExecute.sh
@@ -1,7 +1,8 @@
 signReleaseBundle() {
-  local distUrl=$(eval echo "$"int_"$artifactoryIntegrationName"_distributionUrl)
-  local rtUser=$(eval echo "$"int_"$artifactoryIntegrationName"_user)
-  local rtApiKey=$(eval echo "$"int_"$artifactoryIntegrationName"_apikey)
+  local integrationAlias=$(eval echo "$"res_"$inputReleaseBundleResourceName"_integrationAlias)
+  local distUrl=$(eval echo "$"res_"$inputReleaseBundleResourceName"_"$integrationAlias"_distributionUrl)
+  local rtUser=$(eval echo "$"res_"$inputReleaseBundleResourceName"_"$integrationAlias"_user)
+  local rtApiKey=$(eval echo "$"res_"$inputReleaseBundleResourceName"_"$integrationAlias"_apikey)
   local releaseBundleName=$(eval echo "$"res_"$inputReleaseBundleResourceName"_name)
   local releaseBundleVersion=$(eval echo "$"res_"$inputReleaseBundleResourceName"_version)
 

--- a/steps/SignReleaseBundle/validate.json
+++ b/steps/SignReleaseBundle/validate.json
@@ -63,6 +63,7 @@
         "inputResources": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 1,
           "items": {
             "type": "object",
             "properties": {
@@ -80,6 +81,7 @@
         "outputResources": {
           "type": "array",
           "minItems": 1,
+          "maxItems": 1,
           "items": {
             "type": "object",
             "properties": {
@@ -92,7 +94,7 @@
           }
         }
       },
-      "required": ["integrations", "inputResources"]
+      "required": ["inputResources", "outputResources"]
     },
     "execution": {
       "type": "object",


### PR DESCRIPTION
#389 

Updates SignReleaseBundle to make `integrations` optional and require one input resource and one output.