### PR TITLE
allow resources in PublishBuildInfo

### DIFF
--- a/steps/PublishBuildInfo/validate.json
+++ b/steps/PublishBuildInfo/validate.json
@@ -147,6 +147,23 @@
             "additionalProperties": false
           }
         },
+        "inputResources": {
+          "type": "array",
+          "minItems": 0,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "boolean"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
         "outputResources": {
           "type": "array",
           "minItems": 1,


### PR DESCRIPTION
#393

this should allow the user to give inputResources, though they will not be used for anything in the native step, other than as potential triggers, or in the user's person scripts (onStart, onSuccess, onFailure, onComplete)