### PR TITLE
add validate json for GoPublishBinary

### DIFF
--- a/steps/GoPublishBinary/validate.json
+++ b/steps/GoPublishBinary/validate.json
@@ -1,0 +1,222 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "http://jfrog.com/pipelines/steps/GoPublishBinary.schema.json",
+  "type": "object",
+  "properties": {
+    "name": {
+      "type": "string"
+    },
+    "type": {
+      "type": "string",
+      "enum": ["GoPublishBinary"]
+    },
+    "configuration": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "affinityGroup": {
+          "type": "string"
+        },
+        "timeoutSeconds": {
+          "type": "integer",
+          "exclusiveMinimum": 0
+        },
+        "priority": {
+          "type": "integer",
+          "minimum": 0,
+          "maximum": 10000
+        },
+        "nodePool": {
+          "type": "string"
+        },
+        "chronological": {
+          "type": "boolean"
+        },
+        "runtime": {
+          "type": "object",
+          "properties": {
+            "type": {
+              "type": "string",
+              "enum": ["image", "host"]
+            }
+          },
+          "required": ["type"],
+          "if": {
+            "properties": {
+              "type": { "enum": ["image"] }
+            }
+          },
+          "then": {
+            "properties": {
+              "type": { "enum": ["image"] },
+              "image": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "auto": {
+                    "type": "object",
+                    "required": ["language"],
+                    "properties": {
+                      "language": {
+                        "type": "string"
+                      },
+                      "versions": {
+                        "type": "array",
+                        "items":  {
+                          "type": "string"
+                        }
+                      }
+                    }
+                  },
+                  "custom": {
+                    "type": "object",
+                    "additionalProperties": false,
+                    "required": ["name", "tag"],
+                    "properties": {
+                      "name": {
+                        "type": "string"
+                      },
+                      "tag": {
+                        "type": "string"
+                      },
+                      "options": {
+                        "type": "string"
+                      },
+                      "autoPull": {
+                        "type": "boolean"
+                      }
+                    }
+                  }
+                }
+              }
+            },
+            "additionalProperties": false
+          },
+          "else": {
+            "properties": {
+              "type": { "enum": ["host"] }
+            },
+            "additionalProperties": false
+          }
+        },
+        "integrations": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "inputSteps": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "inputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              },
+              "trigger": {
+                "type": "boolean"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "outputResources": {
+          "type": "array",
+          "minItems": 1,
+          "items": {
+            "type": "object",
+            "properties": {
+              "name": {
+                "type": "string"
+              }
+            },
+            "required": ["name"],
+            "additionalProperties": false
+          }
+        },
+        "fileLocation": {
+          "type": "string"
+        },
+        "fileName": {
+          "type": "string"
+        },
+        "targetRepository": {
+          "type": "string"
+        },
+        "forceXrayScan": {
+          "type": "boolean"
+        },
+        "autoPublishBuildInfo": {
+          "type": "boolean"
+        }
+      },
+      "required": ["inputSteps", "integrations"]
+    },
+    "execution": {
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "onStart": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onSuccess": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onFailure": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onComplete": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "onCancel": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      }
+    }
+  },
+  "required": [
+    "name",
+    "type",
+    "configuration"
+  ],
+  "additionalProperties": false
+}


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/427

```yaml
pipeline:
  - name: pipe1
    steps:
      - name: test_step_1
        type: GoPublishBinary
        configuration:
          #inherits from bash
          # for payloadType go:
          forceXrayScan: <boolean>          # default is false
          autoPublishBuildInfo: <boolean>   # default is false
          fileLocation: <string>            # required if not preceeded by GoBuild
          fileName: <string>                # required if not preceeded by GoBuild
          targetRepository: <string>        # required if not preceeded by GoBuild
          inputSteps:                       # either one of Bash or GoBuild is required
            - name: myBashStep         
            - name: GoBuildStep         
          integrations:
            - name: art                     # required, exactly ONE
          outputResources:
            - name: BuildInfo               # required if autoPublishBuildInfo is true
```