### PR TITLE
adds autoPublishBuildInfo to GradleBuild step

### DIFF
--- a/steps/GradleBuild/execution/onExecute/onExecute.sh
+++ b/steps/GradleBuild/execution/onExecute/onExecute.sh
@@ -43,6 +43,16 @@ GradleBuild() {
     jfrog rt bs $buildName $buildNumber
   fi
 
+  local autoPublishBuildInfo=$(jq -r .step.configuration.autoPublishBuildInfo $step_json_path)
+  if [ "$autoPublishBuildInfo" == "true" ]; then
+    echo "[GradleBuild] Publishing build $buildName/$buildNumber"
+    jfrog rt bp $buildName $buildNumber
+    if [ ! -z "$outputBuildInfoResourceName" ]; then
+      echo "[GradleBuild] Updating output resource: $outputBuildInfoResourceName"
+      write_output $outputBuildInfoResourceName buildName=$buildName buildNumber=$buildNumber
+    fi
+  fi
+
   jfrog rt bce "$buildName" "$buildNumber"
   save_run_state /tmp/jfrog/. jfrog
 }

--- a/steps/GradleBuild/validate.json
+++ b/steps/GradleBuild/validate.json
@@ -32,9 +32,6 @@
         "chronological": {
           "type": "boolean"
         },
-        "forceXrayScan": {
-          "type": "boolean"
-        },
         "environmentVariables": {
           "type": "object",
           "additionalProperties": {
@@ -178,6 +175,12 @@
         },
         "configFileName": {
           "type": "string"
+        },
+        "forceXrayScan": {
+          "type": "boolean"
+        },
+        "autoPublishBuildInfo": {
+          "type": "boolean"
         }
       },
       "required": ["inputResources", "integrations", "gradleCommand",


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/430

## Validation
#### Before
![image](https://user-images.githubusercontent.com/4211715/59409191-55e1fb80-8dd3-11e9-8523-29977c2f2263.png)

#### After
![image](https://user-images.githubusercontent.com/4211715/59409199-5aa6af80-8dd3-11e9-9646-e985ac727aca.png)

## Execution
`outputBuildInfoResourceName` env will be exported in upcoming PR (in which we will injectEnvs in pipelineSync for GradleBuild)

#### Before
![image](https://user-images.githubusercontent.com/4211715/59409230-68f4cb80-8dd3-11e9-81b3-e9658812ac3c.png)

#### After
![image](https://user-images.githubusercontent.com/4211715/59409240-75792400-8dd3-11e9-89c0-a72c0838a635.png)
