### PR TITLE
Allows sourceDistribution instead of sourceArtifactory

### DIFF
--- a/resources/DistributionRule/validate.json
+++ b/resources/DistributionRule/validate.json
@@ -13,7 +13,7 @@
     "configuration": {
       "type": "object",
       "properties": {
-        "sourceArtifactory": {
+        "sourceDistribution": {
           "type": "string"
         },
         "serviceName": {
@@ -34,7 +34,7 @@
         }
       },
       "required": ["serviceName", "cityName", "siteName", "countryCodes",
-        "sourceArtifactory"
+        "sourceDistribution"
       ],
       "additionalProperties": false
     }

--- a/resources/ReleaseBundle/validate.json
+++ b/resources/ReleaseBundle/validate.json
@@ -13,7 +13,7 @@
     "configuration": {
       "type": "object",
       "properties": {
-        "sourceArtifactory": {
+        "sourceDistribution": {
           "type": "string"
         },
         "name": {
@@ -26,7 +26,7 @@
           "type": "boolean"
         }
       },
-      "required": ["name", "version", "sourceArtifactory"]
+      "required": ["name", "version", "sourceDistribution"]
     }
   },
   "required": ["name", "type", "configuration"]

--- a/resources/ReleaseBundle/validate.json
+++ b/resources/ReleaseBundle/validate.json
@@ -26,8 +26,10 @@
           "type": "boolean"
         }
       },
-      "required": ["name", "version", "sourceDistribution"]
+      "required": ["name", "version", "sourceDistribution"],
+      "additionalProperties": false
     }
   },
-  "required": ["name", "type", "configuration"]
+  "required": ["name", "type", "configuration"],
+  "additionalProperties": false
 }


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/463

#### Before
![image](https://user-images.githubusercontent.com/4211715/60263901-81023a00-98ff-11e9-8174-5478e532b872.png)

#### After
![image](https://user-images.githubusercontent.com/4211715/60263913-88c1de80-98ff-11e9-977d-211279550ac3.png)

Added a commit with the check for additional properties in ReleaseBundle. Verified it with the following YML.

```yml
resources:
  - name: fail_rb
    type: ReleaseBundle
    configuration:
      sourceArtifactory: art
      name: unsigned_release_bundle_mvn
      version: v0.0.1
      isSigned: false
```

![image](https://user-images.githubusercontent.com/4211715/60321036-333a1000-9999-11e9-9bc0-f6a926b49530.png)

