### PR TITLE
update PromoteBuild script to use array instead of string to allow multi-word seperated by space

### DIFF
--- a/steps/PromoteBuild/execution/onExecute/onExecute.sh
+++ b/steps/PromoteBuild/execution/onExecute/onExecute.sh
@@ -31,27 +31,29 @@ PromoteBuild() {
   comment=$(jq -r ".step.configuration.comment" $step_json_path)
   copy=$(jq -r ".step.configuration.copy" $step_json_path)
 
-  options=""
+  args=()
   if [ ! -z "$status" ] && [ "$status" != 'null' ]; then
-    options+=" --status $status"
+    args+=("--status")
+    args+=("$status")
   fi
-
   if [ ! -z "$comment" ] && [ "$comment" != 'null' ]; then
-    options+=" --comment $comment"
+   args+=("--comment")
+   args+=("$comment")
   fi
 
   if [ "$copy" == 'true' ]; then
-    options+=" --copy"
+    args+=("--copy")
   fi
 
   if [ "$includeDependencies" == 'true' ]; then
-    options+=" --include-dependencies"
+    args+=("--include-dependencies")
   fi
 
+  args+=("$buildName")
+  args+=("$buildNumber")
+  args+=("$targetRepo")
   echo "[PromoteBuild] Promoting build $buildName/$buildNumber to: $targetRepo"
-  local promoteBuildCmd="jfrog rt build-promote $options $buildName $buildNumber $targetRepo"
-
-  retry_command $promoteBuildCmd
+  retry_command jfrog rt build-promote "${args[@]}"
 
   if [ ! -z "$outputBuildInfoResourceName" ]; then
     echo "[PromoteBuild] Updating output resource: $outputBuildInfoResourceName"


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/477

<img width="1604" alt="Screenshot 2019-07-02 at 3 16 21 PM" src="https://user-images.githubusercontent.com/18304961/60502956-5f78c800-9cdc-11e9-83eb-edd0b2852f15.png">

```yaml
     - name: promote_build_go
        type: PromoteBuild
        configuration:
          targetRepository: promote-test
          comment: "comment test"
          status: "ready"
          copy: true
          includeDependencies: true
          integrations:
            - name: art
          inputResources:
            - name: go_build_info_publish
          outputResources:
            - name: promoted_go_build_info_go_publish
```