### PR TITLE
allows region in Image resource

### DIFF
--- a/resources/Image/validate.json
+++ b/resources/Image/validate.json
@@ -28,6 +28,9 @@
         },
         "autoPull": {
           "type": "boolean"
+        },
+        "region": {
+          "type": "string"
         }
       },
       "required": ["registry", "imageName", "imageTag"]


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/500

#### YML
```yml
resources:
  - name: ecr_image
    type: Image
    configuration:
      registry: aws
      imageName: 854172162208.dkr.ecr.us-east-1.amazonaws.com/sample/custom
      imageTag: latest
      region: us-east-1
      
pipelines:
  - name: img_pipeline
    steps:
      - name: sample_img
        type: Bash
        configuration:
          runtime:
            type: image
            image:
              custom:
                name: drydock/u16node
                tag: master
          inputResources:
            - name: ecr_image
        execution:
          onExecute:
            - sudo docker images
            - test "$res_ecr_image_region" == "us-east-1" 
```

#### Before
![image](https://user-images.githubusercontent.com/4211715/60655480-68e46a80-9e6b-11e9-91bb-68919419c711.png)

#### After 
![image](https://user-images.githubusercontent.com/4211715/60655625-b8c33180-9e6b-11e9-931c-3bc15faa0368.png)
