### PR TITLE
assign dryRun to true if its not mentioned in yaml

### DIFF
--- a/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
+++ b/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
@@ -277,7 +277,7 @@ CreateReleaseBundle() {
   releaseBundleVersionVar=$(jq -r ".step.configuration.releaseBundleVersion" $step_json_path)
   dryRun=$(jq -r ".step.configuration.dryRun" $step_json_path)
   if [ -z "$dryRun" ] || [ "$dryRun" == "null" ]; then
-    $dryRun=true
+    dryRun=true
   fi
   releaseBundleName=$(eval echo "$releaseBundleNameVar")
   releaseBundleVersion=$(eval echo "$releaseBundleVersionVar")


### PR DESCRIPTION
https://github.com/Shippable/pm/issues/12843

CreateReleaseBundle is failing if we don't mention dryRun in the yaml. This is because of a typo while assigning dryRun true.
Instead of `$dryRun=true` it should be `dryRun=true`