### PR TITLE
checks for errors while getting Artifactory service id

### DIFF
--- a/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
+++ b/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
@@ -272,7 +272,7 @@ CreateReleaseBundle() {
   echo -e "\n[CreateReleaseBundle] Getting Artifactory service id"
   local serviceIdResult=$(getArtifactoryServiceId)
   local artifactoryServiceId=""
-  if (echo "$serviceIdResult" | jq .errors > /dev/null); then
+  if (echo "$serviceIdResult" | jq .errors &> /dev/null); then
     echo -e "\n[CreateReleaseBundle] Failed to get Artifactory service id with error: $serviceIdResult"
     exit 1
   else

--- a/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
+++ b/steps/CreateReleaseBundle/execution/onExecute/onExecute.sh
@@ -270,7 +270,14 @@ CreateReleaseBundle() {
   authenticate $buildInfo0
 
   echo -e "\n[CreateReleaseBundle] Getting Artifactory service id"
-  local artifactoryServiceId=$(getArtifactoryServiceId)
+  local serviceIdResult=$(getArtifactoryServiceId)
+  local artifactoryServiceId=""
+  if (echo "$serviceIdResult" | jq .errors > /dev/null); then
+    echo -e "\n[CreateReleaseBundle] Failed to get Artifactory service id with error: $serviceIdResult"
+    exit 1
+  else
+    artifactoryServiceId="$serviceIdResult"
+  fi
 
   # TODO: fix this when setup section gets exported as envs
   releaseBundleNameVar=$(jq -r ".step.configuration.releaseBundleName" $step_json_path)


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/504

When the artifactory integration does not have enough permissions (i.e. admin permission in artifactory), the CreateReleaseBundle behaves as mentioned below.

#### Before
![image](https://user-images.githubusercontent.com/4211715/60886212-fb6f7a00-a26e-11e9-8175-e5de6c58c248.png)

#### After
![image](https://user-images.githubusercontent.com/4211715/60886265-29ed5500-a26f-11e9-9547-94d57aa6cb27.png)

