### PR TITLE
#506; changes default opt_username to JFrog Pipelines.

### DIFF
--- a/steps/Bash/header.sh
+++ b/steps/Bash/header.sh
@@ -807,7 +807,7 @@ send_notification() {
 
   export opt_username="$NOTIFY_USERNAME"
   if [ -z "$opt_username" ]; then
-    opt_username="Shippable"
+    opt_username="JFrog Pipelines"
   fi
 
   export opt_password="$NOTIFY_PASSWORD"


### PR DESCRIPTION
#506 

Changes the default `opt_username` used for Slack, Airbrake, and New Relic.

<img width="325" alt="Screen Shot 2019-07-09 at 2 38 17 PM" src="https://user-images.githubusercontent.com/5492015/60925262-0539b300-a258-11e9-99dc-e123e8b3ac61.png">
