### PR TITLE
update validate json of Bash step to show correct error message for invalid runtime.type

### DIFF
--- a/steps/Bash/validate.json
+++ b/steps/Bash/validate.json
@@ -108,7 +108,7 @@
                         },
                         "region": {
                           "type": "string"
-                        },                        
+                        },
                         "options": {
                           "type": "string"
                         },
@@ -124,10 +124,17 @@
             "additionalProperties": false
           },
           "else": {
-            "properties": {
-              "type": { "enum": ["host"] }
+            "if": {
+              "properties": {
+                "type": { "enum": ["host"] }
+              }
             },
-            "additionalProperties": false
+            "then": {
+              "properties": {
+                "type": { "enum": ["host"] }
+              },
+              "additionalProperties": false
+            }
           }
         },
         "integrations": {


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/508

```yaml
runtime:
            type: foobar
```
<img width="1078" alt="Screenshot 2019-07-10 at 4 22 55 PM" src="https://user-images.githubusercontent.com/18304961/60963661-025dc180-a32f-11e9-8e5a-22b30ec326a4.png">

```yaml
runtime:
            type: host
            image:
              custom:
                name: test
                tag: test
```
<img width="1019" alt="Screenshot 2019-07-10 at 4 24 17 PM" src="https://user-images.githubusercontent.com/18304961/60963733-389b4100-a32f-11e9-812d-a91dd5ec5fa8.png">

```yaml
runtime:
            type: image
            image:
              custom:
                name: test
                tag: test
                language: test
```
<img width="985" alt="Screenshot 2019-07-10 at 4 25 47 PM" src="https://user-images.githubusercontent.com/18304961/60963791-65e7ef00-a32f-11e9-8804-d3fb2fa49506.png">

```yaml
runtime:
            type: image
            image:
              custom:
                language: test
```
<img width="978" alt="Screenshot 2019-07-10 at 4 27 12 PM" src="https://user-images.githubusercontent.com/18304961/60963867-9a5bab00-a32f-11e9-9aa0-cb74c77e7557.png">
