### PR TITLE
marks sourceArtifactory as required for BuildInfo resource

### DIFF
--- a/resources/BuildInfo/validate.json
+++ b/resources/BuildInfo/validate.json
@@ -25,7 +25,7 @@
           "type": "string"
         }
       },
-      "required": ["buildNumber", "buildName"]
+      "required": ["sourceArtifactory", "buildNumber", "buildName"]
     }
   },
   "required": ["name", "type", "configuration"]


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/515

Currently missing sourceArtifactory results in two error messages, one from validate.json and one from pipelineSync's validateBuildInfo.js file. We will prefer using the message from validate.json and the PR for removing the check inside pipelineSync's validateBuildInfo.js will be opened after right after this.

![image](https://user-images.githubusercontent.com/4211715/61123070-03bef380-a4c1-11e9-8c6b-e10c6e543ac2.png)

