### PR TITLE
fail step if the given pattern doesn't exist

### DIFF
--- a/resources/FileSpec/dependsOn.sh
+++ b/resources/FileSpec/dependsOn.sh
@@ -33,6 +33,8 @@ get_file() {
       specs='{}'
       if [ ! -z "$pattern" ]; then
         specs=$(echo $specs | jq --arg pattern $pattern '. + {pattern: $pattern}')
+        echo "Searching for artifacts in the given path: "$pattern
+        jfrog rt s --fail-no-op $pattern
       fi
 
       if [ ! -z "$aql" ]; then


### PR DESCRIPTION
https://github.com/Shippable/kermit-execTemplates/issues/527

when the given pattern file doesn't exist in artifactory

<img width="1118" alt="Screenshot 2019-07-24 at 11 18 41 AM" src="https://user-images.githubusercontent.com/18304961/61768399-fa108680-ae04-11e9-9cf0-88158a4d39f9.png">

when file exists in artifactory
<img width="1571" alt="Screenshot 2019-07-24 at 11 26 45 AM" src="https://user-images.githubusercontent.com/18304961/61768751-fdf0d880-ae05-11e9-9441-c31a29f8b147.png">
