### PR TITLE
#530; updates scriptsbase Dockerfile.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,19 @@
-FROM ${MICRO_NAME}:${MICRO_TAG}
+FROM ${BASE_IMAGE}:${BASE_TAG}
 
-ADD . /jfrog/execTemplates
+ENV NODE_PATH=/shippable/node_modules
+
+ENV BASH_ENV=/etc/drydock/.env
+
+ADD ${MICRO_PATH} /shippable/micro
+
+ADD ${EXEC_TEMPLATES_PATH} /jfrog/execTemplates
 
 ENV EXEC_TEMPLATES_DIR=/jfrog/execTemplates
+
+ADD ${MICRO_PATH}/nod/_global/shippable_retry /shippable/shipctl/shippable_retry
+
+ENV PATH="$PATH:/shippable/shipctl/"
+
+RUN . ~/.nvm/nvm.sh && nvm install 8.16.0 && nvm use 8.16.0 && cd /shippable/micro/nod && npm install
+
+CMD . ~/.nvm/nvm.sh && nvm use 8.16.0 && node app.js


### PR DESCRIPTION
#530 

Updates the scriptsbase Dockerfile to use both kermit and kermit-execTemplates repositories and the drydock/u18node base image.  Confirmed that the pipeline appears correct with the "dry run" option and that an image built from the Dockerfile can be used to run pipelineSync.