### PR TITLE
#524; adds GitRepo webhook validation.

### DIFF
--- a/resources/GitRepo/hookHandler/scripts/ApiAdapter.js
+++ b/resources/GitRepo/hookHandler/scripts/ApiAdapter.js
@@ -1,0 +1,275 @@
+'use strict';
+
+var self = ApiAdapter;
+module.exports = self;
+
+var async = require('async');
+var request = require('request');
+var util = require('util');
+
+function ApiAdapter(token) {
+  console.log('Initializing', self.name);
+
+  // Initialize if token is provided, its a public adapter otherwise.
+  if (token)
+    this.token = token;
+}
+
+var baseUrl = process.env.api_url;
+
+/***********************/
+/*     HTTP METHODS    */
+/***********************/
+/* GET PUT POST DELETE */
+/***********************/
+
+// generic GET method
+ApiAdapter.prototype.get = function (relativeUrl, callback) {
+  console.log('GET data', relativeUrl);
+  var opts = {
+    method: 'GET',
+    url: relativeUrl.indexOf('http') === 0 ?
+      relativeUrl : baseUrl + relativeUrl,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8'
+    }
+  };
+
+  // Only set a token for non-public adapter.
+  if (this.token)
+    /*jshint -W069 */
+    opts.headers['Authorization'] = 'apiToken ' + this.token;
+    /*jshint +W069 */
+
+  var bag = {
+    opts: opts,
+    relativeUrl: relativeUrl,
+    token: this.token
+  };
+
+  async.series([
+      _performCall.bind(null, bag),
+      _parseResponse.bind(null, bag)
+    ],
+    function () {
+      callback(bag.err, bag.parsedBody, bag.res);
+    }
+  );
+};
+
+// generic POST method
+ApiAdapter.prototype.post = function (relativeUrl, json, callback) {
+  console.log('POST data', relativeUrl);
+  var opts = {
+    method: 'POST',
+    url: relativeUrl.indexOf('http') === 0 ?
+      relativeUrl : baseUrl + relativeUrl,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Authorization': 'apiToken ' + this.token
+    },
+    json: json
+  };
+  var bag = {
+    opts: opts,
+    relativeUrl: relativeUrl,
+    token: this.token
+  };
+
+  async.series([
+      _performCall.bind(null, bag),
+      _parseResponse.bind(null, bag)
+    ],
+    function () {
+      callback(bag.err, bag.parsedBody, bag.res);
+    }
+  );
+};
+
+// generic PUT method
+ApiAdapter.prototype.put = function (relativeUrl, json, callback) {
+  console.log('PUT data', relativeUrl);
+  var opts = {
+    method: 'PUT',
+    url: relativeUrl.indexOf('http') === 0 ?
+      relativeUrl : baseUrl + relativeUrl,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Authorization': 'apiToken ' + this.token
+    },
+    json: json
+  };
+  var bag = {
+    opts: opts,
+    relativeUrl: relativeUrl,
+    token: this.token
+  };
+
+  async.series([
+      _performCall.bind(null, bag),
+      _parseResponse.bind(null, bag)
+    ],
+    function () {
+      callback(bag.err, bag.parsedBody, bag.res);
+    }
+  );
+};
+
+// generic DELETE method
+ApiAdapter.prototype.delete = function (relativeUrl, callback) {
+  var opts = {
+    method: 'DELETE',
+    url: relativeUrl.indexOf('http') === 0 ?
+      relativeUrl : baseUrl + relativeUrl,
+    headers: {
+      'Content-Type': 'application/json; charset=utf-8',
+      'Authorization': 'apiToken ' + this.token
+    }
+  };
+
+  var bag = {
+    opts: opts,
+    relativeUrl: relativeUrl,
+    token: this.token
+  };
+
+  async.series([
+      _performCall.bind(null, bag),
+      _parseResponse.bind(null, bag)
+    ],
+    function () {
+      callback(bag.err, bag.parsedBody, bag.res);
+    }
+  );
+};
+
+// common helper methods
+function _performCall(bag, next) {
+  var who = self.name + '|' + _performCall.name;
+  console.log('Inside', who);
+
+  bag.startedAt = Date.now();
+  request(bag.opts,
+    function (err, res, body) {
+      var interval = Date.now() - bag.startedAt;
+      console.log('Request ' + bag.opts.method + ' ' +
+        bag.relativeUrl + ' took ' + interval +
+        ' ms and returned HTTP status ' + (res && res.statusCode));
+
+      bag.res = res;
+      bag.body = body;
+      bag.statusCode = res && res.statusCode;
+      if (res && res.statusCode > 299) err = err || res.statusCode;
+      if (err) {
+        console.log('Returned status', err,
+          'for request', bag.relativeUrl);
+        bag.err = err;
+      }
+      return next();
+    }
+  );
+}
+
+function _parseResponse(bag, next) {
+  var who = self.name + '|' + _parseResponse.name;
+  console.log('Inside', who);
+
+  if (bag.err)
+    bag.err = bag.opts.method + ' ' + bag.relativeUrl + ' returned ' + bag.err;
+
+  if (bag.body) {
+    if (typeof bag.body === 'object') {
+      bag.parsedBody = bag.body;
+      if (bag.err && bag.parsedBody && bag.parsedBody.id)
+        bag.err = bag.parsedBody;
+    } else {
+      try {
+        bag.parsedBody = JSON.parse(bag.body);
+        if (bag.err && bag.parsedBody && bag.parsedBody.id)
+          bag.err = bag.parsedBody;
+      } catch (e) {
+        if (!bag.err)
+          console.log('Unable to parse bag.body', bag.body, e);
+        bag.err = bag.err || 'Could not parse response';
+      }
+    }
+  }
+
+  if (bag.err)
+    bag.err.statusCode = bag.statusCode;
+
+  return next();
+}
+
+/***************************/
+/*         ROUTES          */
+/***************************/
+/* Sorted alphabetically   */
+/* by object name          */
+/***************************/
+
+// hooks
+ApiAdapter.prototype.getHookById =
+  function (hookId, callback) {
+    var url = '/hooks/' + hookId;
+    this.get(url, callback);
+  };
+
+// projectIntegrations
+ApiAdapter.prototype.getProjectIntegrationById =
+  function (projectIntegrationId, callback) {
+    var url = '/projectIntegrations/' + projectIntegrationId;
+    this.get(url, callback);
+  };
+
+// resources
+ApiAdapter.prototype.getResourceById =
+  function (resourceId, callback) {
+    var url = '/resources/' + resourceId;
+    this.get(url, callback);
+  };
+
+ApiAdapter.prototype.getResources =
+  function (query, callback) {
+    var url = '/resources?' + query;
+    this.get(url, callback);
+  };
+
+// resourceVersions
+ApiAdapter.prototype.getResourceVersions =
+  function (query, callback) {
+    var url = '/resourceVersions?' + query;
+    this.get(url, callback);
+  };
+
+ApiAdapter.prototype.getResourceVersionById =
+  function (resourceVersionId, callback) {
+    var url = '/resourceVersions/' + resourceVersionId;
+    this.get(url, callback);
+  };
+
+// resourceVersions
+ApiAdapter.prototype.postResourceVersion =
+  function (json, callback) {
+    var url = '/resourceVersions';
+    this.post(url, json, callback);
+  };
+
+//system Codes
+ApiAdapter.prototype.getSystemCodes =
+  function (callback) {
+    this.get(
+      util.format('/systemCodes'),
+      callback
+    );
+  };
+
+// vortex
+ApiAdapter.prototype.postToVortex = function (where, message, callback) {
+  var json = {
+    where: where,
+    payload: message
+  };
+  var url = '/vortex';
+  this.post(url, json, callback);
+};

--- a/resources/GitRepo/hookHandler/scripts/bitbucket/validateWebhook.js
+++ b/resources/GitRepo/hookHandler/scripts/bitbucket/validateWebhook.js
@@ -1,0 +1,142 @@
+'use strict';
+
+var self = validateWebhook;
+module.exports = self;
+
+var async = require('async');
+var util = require('util');
+var runTypes = require('../runTypes.js');
+
+function validateWebhook(reqBody, reqHeaders, callback) {
+  var bag = {
+    reqBody: reqBody,
+    reqHeaders: reqHeaders,
+    parsedPayload: null,
+    isValidWebhook: true,
+  };
+
+  bag.who = util.format('bitbucket|%s', self.name);
+  console.log(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _parsePayload.bind(null, bag),
+      _setWebhookType.bind(null, bag),
+      _validateWebhookCommit.bind(null, bag),
+      _validateWebhookPullRequest.bind(null, bag),
+      _validateWebhookPullRequestClose.bind(null, bag)
+    ],
+    function (err) {
+      console.log(bag.who, 'Completed');
+      return callback(err, bag.isValidWebhook);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  console.log(who, 'Inside');
+
+  if (!bag.reqBody)
+    return next('Missing data: reqBody');
+  if (!bag.reqHeaders)
+    return next('Missing data: reqHeaders');
+  if (!bag.reqHeaders.authorization)
+    return next('Missing data: reqHeaders.authorization');
+
+  return next();
+}
+
+function _parsePayload(bag, next) {
+  var who = bag.who + '|' + _parsePayload.name;
+  console.log(who, 'Inside');
+
+  bag.parsedPayload = bag.reqBody;
+  return next();
+}
+
+function _setWebhookType(bag, next) {
+  var who = bag.who + '|' + _setWebhookType.name;
+  console.log(who, 'Inside');
+
+  var bitbucketEvent = bag.reqHeaders['x-event-key'];
+  /* jshint camelcase:false */
+  if (bitbucketEvent === 'repo:push') {
+    bag.webhookType = runTypes.WEBHOOK_COMMIT; // May be a tag webhook
+  } else if (bitbucketEvent === 'pullrequest:created') {
+    bag.webhookType = runTypes.WEBHOOK_PR;
+  } else if (bitbucketEvent === 'pullrequest:updated') {
+    bag.webhookType = runTypes.WEBHOOK_PR;
+  } else if (bitbucketEvent === 'pullrequest:rejected') {
+    bag.webhookType = runTypes.WEBHOOK_PR_CLOSE;
+  } else {
+    console.log(who, 'Ignoring Bitbucket webhook because of an ' +
+       'unsupported event ' + bitbucketEvent + ' in headers for project ' +
+        bag.parsedPayload.repository.full_name);
+    bag.isValidWebhook = false;
+  }
+  /* jshint camelcase:true */
+
+  return next();
+}
+
+function _validateWebhookCommit(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_COMMIT) return next();
+
+  var who = bag.who + '|' + _validateWebhookCommit.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  if (!bag.parsedPayload.push || !bag.parsedPayload.push.changes) {
+    console.log(who, 'Ignoring Bitbucket push webhook because ' +
+       'because the payload does not contain the push event for project ' +
+       bag.parsedPayload.repository.full_name);
+    bag.isValidWebhook = false;
+    return next();
+  }
+
+  var commitMessage = null;
+
+  var lastCommit = bag.parsedPayload.push.changes[0];
+  if (lastCommit) {
+    if (!lastCommit.new) {
+      console.log(who, 'Ignoring Bitbucket push webhook because ' +
+       'push event was a result of deletion of a reference for project ' +
+       bag.parsedPayload.repository.full_name);
+      // Deleted branch
+      bag.isValidWebhook = false;
+      return next();
+    }
+    commitMessage = lastCommit.new.target.message;
+  }
+
+  /* jshint camelcase:true */
+  return next();
+}
+
+function _validateWebhookPullRequest(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_PR) return next();
+
+  var who = bag.who + '|' + _validateWebhookPullRequest.name;
+  console.log(who, 'Inside');
+
+  if (!bag.parsedPayload.pullrequest)
+    return next('Missing body data: payload.pullrequest');
+
+  return next();
+}
+
+function _validateWebhookPullRequestClose(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_PR_CLOSE) return next();
+
+  var who = bag.who + '|' + _validateWebhookPullRequestClose.name;
+  console.log(who, 'Inside');
+
+  if (!bag.parsedPayload.pullrequest)
+    return next('Missing body data: payload.pullrequest');
+
+  return next();
+}

--- a/resources/GitRepo/hookHandler/scripts/bitbucketServer/validateWebhook.js
+++ b/resources/GitRepo/hookHandler/scripts/bitbucketServer/validateWebhook.js
@@ -1,0 +1,110 @@
+'use strict';
+
+var self = validateWebhook;
+module.exports = self;
+
+var async = require('async');
+var util = require('util');
+var _ = require('underscore');
+var runTypes = require('../runTypes.js');
+
+function validateWebhook(reqBody, reqHeaders, callback) {
+  var bag = {
+    reqBody: reqBody,
+    reqHeaders: reqHeaders,
+    parsedPayload: null,
+    isValidWebhook: true,
+  };
+
+  bag.who = util.format('bitbucketServer|%s', self.name);
+  console.log(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _setWebhookType.bind(null, bag),
+      _validateWebhookCommit.bind(null, bag)
+    ],
+    function (err) {
+      console.log(bag.who, 'Completed');
+      return callback(err, bag.isValidWebhook);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  console.log(who, 'Inside');
+
+  if (!bag.reqBody)
+    return next('Missing data: reqBody');
+
+  if (!bag.reqHeaders)
+    return next('Missing data: reqHeaders');
+
+  if (!(bag.reqHeaders.authorization ||
+    _.has(bag.reqHeaders, 'x-hub-signature')))
+    return next(
+      'Missing data: reqHeaders.authorization or reqHeaders.x-hub-signature');
+
+  return next();
+}
+
+function _setWebhookType(bag, next) {
+  var who = bag.who + '|' + _setWebhookType.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  var bitbucketServerEvent = bag.reqHeaders['x-bitbucket-server-event'] ||
+    bag.reqHeaders['x-event-key'];
+  bag.repoName = bag.reqBody.repository && bag.reqBody.repository.name;
+  if (bitbucketServerEvent === 'push' ||
+    (bitbucketServerEvent === 'repo:refs_changed' &&
+    _.first(bag.reqBody.changes).ref.type === 'BRANCH' &&
+    _.first(bag.reqBody.changes).type === 'UPDATE')) {
+    bag.webhookType = runTypes.WEBHOOK_COMMIT;
+  } else if (bitbucketServerEvent === 'pullrequest:created' ||
+    bitbucketServerEvent === 'pr:opened') {
+    bag.webhookType = runTypes.WEBHOOK_PR;
+  } else if (bitbucketServerEvent === 'pullrequest:updated') {
+    bag.webhookType = runTypes.WEBHOOK_PR;
+  } else if (bitbucketServerEvent === 'pr:declined') {
+     bag.webhookType = runTypes.WEBHOOK_PR_CLOSE;
+  } else if (bitbucketServerEvent === 'tag') {
+    bag.webhookType = runTypes.WEBHOOK_TAG;
+  } else if (bitbucketServerEvent === 'repo:refs_changed' &&
+    _.first(bag.reqBody.changes).ref.type === 'TAG' &&
+    _.first(bag.reqBody.changes).type === 'ADD') {
+    bag.webhookType = runTypes.WEBHOOK_TAG;
+  } else {
+    console.log(who, 'Ignoring Bitbucket Server webhook because of an ' +
+       'unsupported event ' + bitbucketServerEvent +
+       ' in headers for project ' + bag.repoName);
+    bag.isValidWebhook = false;
+  }
+  /* jshint camelcase:true */
+
+  return next();
+}
+
+function _validateWebhookCommit(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_COMMIT) return next();
+
+  var who = bag.who + '|' + _validateWebhookCommit.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  if (_.isEmpty(bag.reqBody.changesets) && _.isEmpty(bag.reqBody.changes)) {
+    console.log(who, 'Ignoring Bitbucket Server push webhook because ' +
+      'commits were not found.');
+    bag.isValidWebhook = false;
+    return next();
+  }
+
+  var commitMessage;
+  if (!_.isEmpty(bag.reqBody.changesets))
+    commitMessage = bag.reqBody.changesets[0].toCommit.message;
+
+  /* jshint camelcase:true */
+  return next();
+}

--- a/resources/GitRepo/hookHandler/scripts/github/validateWebhook.js
+++ b/resources/GitRepo/hookHandler/scripts/github/validateWebhook.js
@@ -1,0 +1,235 @@
+'use strict';
+
+var self = validateWebhook;
+module.exports = self;
+
+var async = require('async');
+var util = require('util');
+var runTypes = require('../runTypes.js');
+
+function validateWebhook(reqBody, reqHeaders, callback) {
+  var bag = {
+    reqBody: reqBody,
+    reqHeaders: reqHeaders,
+    parsedPayload: null,
+    isValidWebhook: true
+  };
+
+  bag.who = util.format('github|%s', self.name);
+  console.log(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _parsePayload.bind(null, bag),
+      _checkZenWebhook.bind(null, bag),
+      _setWebhookType.bind(null, bag),
+      _validateWebhookCommit.bind(null, bag),
+      _validateWebhookPullRequest.bind(null, bag),
+      _validateWebhookPullRequestClose.bind(null, bag),
+      _validateWebhookRelease.bind(null, bag),
+      _validateWebhookTag.bind(null, bag)
+    ],
+    function (err) {
+      console.log(bag.who, 'Completed');
+      return callback(err, bag.isValidWebhook);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  console.log(who, 'Inside');
+
+  if (!bag.reqBody)
+    return next('Missing body');
+
+  if (!bag.reqHeaders)
+    return next('Missing headers');
+
+  if (!bag.reqHeaders.authorization)
+    return next('Missing header data :authorization');
+
+  return next();
+}
+
+function _parsePayload(bag, next) {
+  var who = bag.who + '|' + _parsePayload.name;
+  console.log(who, 'Inside');
+
+  var payload = null;
+  try {
+    payload = JSON.parse(bag.reqBody.payload);
+  } catch (e) {
+    return next('Error parsing payload: ' + util.inspect(e));
+  }
+  bag.parsedPayload = payload;
+
+  return next();
+}
+
+function _checkZenWebhook(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (!bag.parsedPayload.zen) return next();
+
+  var who = bag.who + '|' + _checkZenWebhook.name;
+  console.log(who, 'Inside');
+
+  console.log('Ignoring the github webhook ping', who);
+
+  bag.isValidWebhook = false;
+
+  return next();
+}
+
+function _setWebhookType(bag, next) {
+  if (!bag.isValidWebhook) return next();
+
+  var who = bag.who + '|' + _setWebhookType.name;
+  console.log(who, 'Inside');
+
+  var githubEvent = bag.reqHeaders['x-github-event'];
+  var tagMatcher = new RegExp(/refs\/tags\/(.*)/);
+  var ref = bag.parsedPayload.ref;
+  var isTagPush = tagMatcher.test(ref);
+
+  if (githubEvent === 'push' && !isTagPush) {
+    bag.webhookType = runTypes.WEBHOOK_COMMIT;
+    return next();
+  }
+
+  if (githubEvent === 'pull_request') {
+    var action = bag.parsedPayload.action;
+    if (action === 'closed')
+      bag.webhookType = runTypes.WEBHOOK_PR_CLOSE;
+    else
+      bag.webhookType = runTypes.WEBHOOK_PR;
+    return next();
+  }
+
+  if (githubEvent === 'release') {
+    bag.webhookType = runTypes.WEBHOOK_RELEASE;
+    return next();
+  }
+
+  if (githubEvent === 'push' && isTagPush) {
+    bag.webhookType = runTypes.WEBHOOK_TAG;
+    return next();
+  }
+
+  return next('No valid webhook event in headers.');
+}
+
+function _validateWebhookCommit(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_COMMIT) return next();
+
+  var who = bag.who + '|' + _validateWebhookCommit.name;
+  console.log(who, 'Inside');
+
+  if (!bag.parsedPayload.pusher)
+    return next('Missing body data :payload.pusher');
+  /* jshint camelcase:false */
+  if (!bag.parsedPayload.head_commit) {
+    console.log(who,'Ignoring GitHub push webhook because the ' +
+      'push event was a result of deletion of a reference for project ' +
+      bag.parsedPayload.repository.full_name);
+    bag.isValidWebhook = false;
+    return next();
+  }
+  /* jshint camelcase:true */
+
+  if (bag.parsedPayload.ref || bag.parsedPayload.after)
+    return next();
+
+  return next('Missing body data :payload.ref or :payload.after');
+}
+
+function _validateWebhookPullRequest(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_PR) return next();
+
+  var who = bag.who + '|' + _validateWebhookPullRequest.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  if (!bag.parsedPayload.pull_request)
+  /* jshint camelcase:true */
+    return next('Missing body data :payload.pull_request');
+
+  /* jshint camelcase:false */
+  var action = bag.parsedPayload.action;
+  if (action === 'opened' || action === 'synchronize' || action === 'reopened')
+    return next();
+
+  console.log(who, 'Ignoring GitHub webhook PR webhook because of ' +
+    'unsupported ' + bag.parsedPayload.action + ' action for project '+
+    bag.parsedPayload.repository.full_name);
+  bag.isValidWebhook = false;
+  return next();
+  /* jshint camelcase:true */
+}
+
+function _validateWebhookPullRequestClose(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_PR_CLOSE) return next();
+
+  var who = bag.who + '|' + _validateWebhookPullRequestClose.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  if (!bag.parsedPayload.pull_request)
+  /* jshint camelcase:true */
+    return next('Missing body data :payload.pull_request');
+
+  return next();
+}
+
+function _validateWebhookRelease(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_RELEASE) return next();
+
+  var who = bag.who + '|' + _validateWebhookRelease.name;
+  console.log(who, 'Inside');
+
+  if (!bag.parsedPayload.release)
+    return next('Missing body date :payload.release');
+
+  // At the time of writing, 'published' is the only valid value for action
+  // on release webhooks
+  if (bag.parsedPayload.action === 'published')
+    return next();
+
+  /* jshint camelcase:false */
+  console.log(who, 'Ignoring GitHub release webhook because of ' +
+    'unsupported ' + bag.parsedPayload.action + ' action for project '+
+    bag.parsedPayload.repository.full_name);
+  /* jshint camelcase:true */
+
+  bag.isValidWebhook = false;
+  return next();
+}
+
+function _validateWebhookTag(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_TAG) return next();
+
+  var who = bag.who + '|' + _validateWebhookTag.name;
+  console.log(who, 'Inside');
+
+  if (!bag.parsedPayload.pusher)
+    return next('Missing body data :payload.pusher');
+  /* jshint camelcase:false */
+  if (!bag.parsedPayload.head_commit) {
+    console.log(who,'Ignoring GitHub push webhook because the ' +
+      'push event was a result of deletion of a reference for project ' +
+       bag.parsedPayload.repository.full_name);
+    bag.isValidWebhook = false;
+    return next();
+  }
+  /* jshint camelcase:true */
+
+  if (bag.parsedPayload.ref || bag.parsedPayload.after)
+    return next();
+
+  return next('Missing body data :payload.ref or :payload.after');
+}

--- a/resources/GitRepo/hookHandler/scripts/gitlab/validateWebhook.js
+++ b/resources/GitRepo/hookHandler/scripts/gitlab/validateWebhook.js
@@ -1,0 +1,121 @@
+'use strict';
+
+var self = validateWebhook;
+module.exports = self;
+
+var async = require('async');
+var util = require('util');
+var _ = require('underscore');
+var runTypes = require('../runTypes.js');
+
+function validateWebhook(reqBody, reqHeaders, callback) {
+  var bag = {
+    reqBody: reqBody,
+    reqHeaders: reqHeaders,
+    parsedPayload: null,
+    isValidWebhook: true,
+  };
+
+  bag.who = util.format('gitlab|%s', self.name);
+  console.log(bag.who, 'Starting');
+
+  async.series([
+      _checkInputParams.bind(null, bag),
+      _parsePayload.bind(null, bag),
+      _setWebhookType.bind(null, bag),
+      _validateWebhookCommit.bind(null, bag),
+      _validateWebhookPullRequest.bind(null, bag)
+    ],
+    function (err) {
+      console.log(bag.who, 'Completed');
+      return callback(err, bag.isValidWebhook);
+    }
+  );
+}
+
+function _checkInputParams(bag, next) {
+  var who = bag.who + '|' + _checkInputParams.name;
+  console.log(who, 'Inside');
+
+  if (!bag.reqBody)
+    return next('Missing data: reqBody');
+  if (!bag.reqHeaders)
+    return next('Missing data: reqHeaders');
+  if (!bag.reqHeaders.authorization)
+    return next('Missing data: reqHeaders.authorization');
+
+  return next();
+}
+
+function _parsePayload(bag, next) {
+  var who = bag.who + '|' + _parsePayload.name;
+  console.log(who, 'Inside');
+
+  bag.parsedPayload = bag.reqBody;
+  return next();
+}
+
+function _setWebhookType(bag, next) {
+  var who = bag.who + '|' + _setWebhookType.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  var gitlabEvent = bag.reqHeaders['x-gitlab-event'];
+  if (gitlabEvent === 'Push Hook') {
+    bag.webhookType = runTypes.WEBHOOK_COMMIT;
+  } else if (gitlabEvent === 'Merge Request Hook') {
+    var action = bag.parsedPayload.object_attributes.action;
+    if (action === 'close')
+      bag.webhookType = runTypes.WEBHOOK_PR_CLOSE;
+    else
+      bag.webhookType = runTypes.WEBHOOK_PR;
+  } else if (gitlabEvent === 'Tag Push Hook') {
+    bag.webhookType = runTypes.WEBHOOK_TAG;
+  } else {
+    console.log(who, 'Ignoring GitLab webhook because of an ' +
+      'unsupported event ' + gitlabEvent + ' in headers for project ' +
+      bag.parsedPayload.repository.name);
+    bag.isValidWebhook = false;
+  }
+  /* jshint camelcase:true */
+
+  return next();
+}
+
+function _validateWebhookCommit(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_COMMIT) return next();
+
+  var who = bag.who + '|' + _validateWebhookCommit.name;
+  console.log(who, 'Inside');
+
+  if (_.isEmpty(bag.reqBody.commits)) {
+    console.log(who, 'Ignoring GitLab push webhook because commits ' +
+      'were not found.');
+    bag.isValidWebhook = false;
+    return next();
+  }
+
+  return next();
+}
+
+function _validateWebhookPullRequest(bag, next) {
+  if (!bag.isValidWebhook) return next();
+  if (bag.webhookType !== runTypes.WEBHOOK_PR) return next();
+
+  var who = bag.who + '|' + _validateWebhookPullRequest.name;
+  console.log(who, 'Inside');
+
+  /* jshint camelcase:false */
+  var action = bag.parsedPayload.object_attributes.action;
+  /* jshint camelcase:true */
+  if (action === 'open' || action === 'reopen' || action === 'update')
+    console.log(who, 'Allowing supported GitLab PR webhook action: ' + action);
+  else {
+    console.log(who, 'Ignoring GitLab PR webhook because of unsupported ' +
+      action + ' action for project '+ bag.parsedPayload.project.name);
+    bag.isValidWebhook = false;
+  }
+
+  return next();
+}

--- a/resources/GitRepo/hookHandler/scripts/package.json
+++ b/resources/GitRepo/hookHandler/scripts/package.json
@@ -1,0 +1,43 @@
+{
+  "name": "pipelines.hookHandler",
+  "license": "UNLICENSED",
+  "private": true,
+  "repository": {
+    "type": "git",
+    "url": "git@github.com:Shippable/kermit-execTemplates.git"
+  },
+  "dependencies": {
+    "async": "2.0.0",
+    "fs-extra": "0.30.0",
+    "request": "2.88.0",
+    "underscore": "1.8.3",
+    "ursa": "0.9.4",
+    "util": "0.10.3",
+    "winston": "2.2.0"
+  },
+  "jshintConfig": {
+    "node": true,
+    "jquery": true,
+    "undef": true,
+    "noarg": true,
+    "white": true,
+    "esnext": true,
+    "strict": true,
+    "nonbsp": true,
+    "eqeqeq": true,
+    "unused": true,
+    "maxlen": 80,
+    "indent": 2,
+    "bitwise": true,
+    "noempty": true,
+    "latedef": "nofunc",
+    "maxdepth": 5,
+    "quotmark": "single",
+    "trailing": true,
+    "maxparams": 18,
+    "globalstrict": true,
+    "maxcomplexity": 20,
+    "maxstatements": 50,
+    "predef": []
+  }
+}

--- a/resources/GitRepo/hookHandler/scripts/runTypes.js
+++ b/resources/GitRepo/hookHandler/scripts/runTypes.js
@@ -1,0 +1,61 @@
+'use strict';
+
+var _ = require('underscore');
+
+/**
+ * Global enum for Build Triggers
+ * The system can ONLY have builds triggered by
+ * actions specified here.
+ **/
+
+exports.INVALID = 10;
+exports.MANUAL_BRANCH = 20;
+exports.MANUAL_COMMIT = 30;
+exports.MANUAL_PR = 40;
+exports.WEBHOOK_COMMIT = 50;
+exports.WEBHOOK_PR = 60;
+exports.RE_RUN = 70;
+exports.WEBHOOK_RELEASE = 80;
+exports.WEBHOOK_TAG = 90;
+exports.WEBHOOK_PR_CLOSE = 100;
+exports.WEBHOOK_COMMENT = 110;
+
+exports.names = [
+  'INVALID',
+  'MANUAL_BRANCH',
+  'MANUAL_COMMIT',
+  'MANUAL_PR',
+  'WEBHOOK_COMMIT',
+  'WEBHOOK_PR',
+  'RE_RUN',
+  'WEBHOOK_RELEASE',
+  'WEBHOOK_TAG',
+  'WEBHOOK_PR_CLOSE',
+  'WEBHOOK_COMMENT'
+];
+
+exports.manualBuildTypes = [
+  exports.MANUAL_BRANCH,
+  exports.MANUAL_COMMIT,
+  exports.MANUAL_PR,
+  exports.RE_RUN
+];
+
+exports.webhookBuildTypes = [
+  exports.WEBHOOK_COMMIT,
+  exports.WEBHOOK_PR,
+  exports.WEBHOOK_RELEASE,
+  exports.WEBHOOK_TAG,
+  exports.WEBHOOK_PR_CLOSE,
+  exports.WEBHOOK_COMMENT
+];
+
+exports.lookup = function (code) {
+  var codes = exports;
+
+  return _.find(codes.names,
+    function (codeName) {
+      return codes[codeName] === code;
+    }
+  );
+};

--- a/resources/GitRepo/hookHandler/scripts/validateWebhook.js
+++ b/resources/GitRepo/hookHandler/scripts/validateWebhook.js
@@ -1,0 +1,212 @@
+'use strict';
+
+var self = validateWebhook;
+module.exports = self;
+
+var crypto = require('crypto');
+var async = require('async');
+var fs = require('fs');
+var util = require('util');
+var _ = require('underscore');
+
+var ApiAdapter = require('./ApiAdapter.js');
+
+var validationStrategies = {
+  bitbucket: require('./bitbucket/validateWebhook.js'),
+  bitbucketServer: require('./bitbucketServer/validateWebhook.js'),
+  github: require('./github/validateWebhook.js'),
+  gitlab: require('./gitlab/validateWebhook.js')
+};
+
+function validateWebhook() {
+  var bag = {
+    hookId: process.env.hook_id,
+    apiAdapter: new ApiAdapter(process.env.api_token),
+    reqHeaders: {},
+    reqBody: {},
+    isValidWebhook: false
+  };
+
+  bag.who = util.format('hooks|%s|id:', self.name, bag.hookId);
+  console.log(bag.who, 'Starting');
+
+  async.series([
+      _readHeaders.bind(null, bag),
+      _readBody.bind(null, bag),
+      _getHook.bind(null, bag),
+      _getHookIntegration.bind(null, bag),
+      _validateWebhook.bind(null, bag),
+      _authorizeWebhook.bind(null, bag)
+    ],
+    function (err) {
+      console.log(bag.who, 'Completed');
+      if (err)
+        process.exit(1);
+
+    }
+  );
+}
+
+function _readHeaders(bag, next) {
+  var who = bag.who + '|' + _readHeaders.name;
+  console.log(who, 'Inside');
+
+  var headersFilePath = process.env.hook_headers_path;
+
+  fs.readFile(headersFilePath, 'utf8',
+    function (err, data) {
+      if (err) {
+        console.log(who, 'Failed to read headers file with error: ' +
+          util.inspect(err));
+        return next(err);
+      }
+
+      try {
+        console.log(who, 'Parsing headers file');
+        bag.reqHeaders = JSON.parse(data);
+      } catch (e) {
+        console.log(who, 'Failed to parse headers file ' +
+          'with error: ' + util.inspect(e));
+        return next(e);
+      }
+
+      return next();
+    }
+  );
+}
+
+function _readBody(bag, next) {
+  var who = bag.who + '|' + _readBody.name;
+  console.log(who, 'Inside');
+
+  var bodyFilePath = process.env.hook_body_path;
+
+  fs.readFile(bodyFilePath, 'utf8',
+    function (err, data) {
+      if (err) {
+        console.log(who, 'Failed to read body file ' +
+          'with error: ' + util.inspect(err));
+          return next(err);
+      }
+
+      try {
+        console.log(who, 'Parsing body file');
+        bag.reqBody = JSON.parse(data);
+      } catch (e) {
+        console.log(who, 'Failed to parse body file ' +
+          'with error: ' + util.inspect(e));
+        return next(e);
+      }
+
+      return next();
+    }
+  );
+}
+
+function _getHook(bag, next) {
+  var who = bag.who + '|' + _getHook.name;
+  console.log(who, 'Inside');
+
+  bag.apiAdapter.getHookById(bag.hookId,
+    function (err, hook) {
+      if (err) {
+        var msg = util.format('getHookById failed for id: %s ' +
+          'with error: %s', bag.hookId, err.message);
+        return next(msg);
+      }
+
+      bag.hook = hook;
+      return next();
+    }
+  );
+}
+
+function _getHookIntegration(bag, next) {
+  var who = bag.who + '|' + _getHookIntegration.name;
+  console.log(who, 'Inside');
+
+  bag.apiAdapter.getProjectIntegrationById(bag.hook.projectIntegrationId,
+    function (err, integration) {
+      if (err) {
+        var msg = util.format('getProjectIntegrationById failed for id: %s ' +
+          'with error: %s', bag.hook.projectIntegrationId, err.message);
+        return next(msg);
+      }
+
+      bag.integration = integration;
+      return next();
+    }
+  );
+}
+
+function _validateWebhook(bag, next) {
+  var who = bag.who + '|' + _validateWebhook.name;
+  console.log(who, 'Inside');
+
+  var strategy = null;
+  if (_.has(bag.reqHeaders, 'x-github-event'))
+    strategy = validationStrategies.github;
+  else if (_.has(bag.reqHeaders, 'x-event-key') && _.has(bag.reqHeaders,
+    'x-request-uuid'))
+    strategy = validationStrategies.bitbucket;
+  else if (_.has(bag.reqHeaders, 'x-gitlab-event'))
+    strategy = validationStrategies.gitlab;
+  else if (_.has(bag.reqHeaders, 'x-bitbucket-server-event') ||
+    (_.has(bag.reqHeaders, 'x-event-key') && _.has(bag.reqHeaders,
+      'x-request-id')))
+    strategy = validationStrategies.bitbucketServer;
+
+  if (!strategy)
+    return next('A webhook with unsupported headers was ignored' +
+    ' for hookId: ' + bag.hookId +
+    ' from sourceProvider ' + bag.reqHeaders['user-agent']);
+
+  strategy(bag.reqBody, bag.reqHeaders,
+    function (err, isValidWebhook) {
+      if (err)
+        return next('Error validating webhook for hookId ' +
+            bag.hookId + ' ' + util.inspect(err));
+
+      if (!isValidWebhook)
+        return next('Invalid webhook for hookId ' + bag.hookId);
+
+      return next();
+    }
+  );
+}
+
+function _authorizeWebhook(bag, next) {
+  var who = bag.who + '|' + _authorizeWebhook.name;
+  console.log(who, 'Inside');
+
+  if ((bag.integration.masterIntegrationName === 'bitbucketServer' ||
+    bag.integration.masterIntegrationName === 'bitbucketServerBasic') &&
+    _.has(bag.reqHeaders, 'x-hub-signature')) {
+      var secret = bag.hook.propertyBag.username + ':' +
+        bag.hook.propertyBag.password;
+      var body = JSON.stringify(bag.reqBody);
+      var hmac = crypto.createHmac('sha256', secret).update(body).digest('hex');
+      if (('sha256=' + hmac) === bag.reqHeaders['x-hub-signature'])
+        return next();
+    }
+
+    var headerValues = bag.reqHeaders.authorization &&
+      bag.reqHeaders.authorization.split(' ');
+    var scheme = headerValues && headerValues[0];
+    if (scheme === 'Basic') {
+      var credentials = headerValues[1];
+      var decoded = new Buffer(credentials, 'base64').toString();
+      var user = decoded.split(':')[0];
+      var pass = decoded.split(':')[1];
+
+      if (user === bag.hook.propertyBag.username &&
+        pass === bag.hook.propertyBag.password) {
+        console.log('Webhook authenticated for hookId', bag.hookId);
+        return next();
+      }
+    }
+
+    return next('Unauthorized webhook received for hookId: ' + bag.hookId);
+}
+
+validateWebhook();

--- a/resources/GitRepo/hookHandler/validate.sh
+++ b/resources/GitRepo/hookHandler/validate.sh
@@ -1,0 +1,7 @@
+validate_webhook() {
+  cd scripts
+  npm install
+  node validateWebhook.js
+}
+
+validate_webhook


### PR DESCRIPTION
#524 

Copies webhook validation to execTemplates for hookHandler.  Confirmed that a webhook for each provider still passes validation.  These will be further tested when the scripts to create resource versions are added.